### PR TITLE
Fix checkout redirection issue

### DIFF
--- a/examples/nextjs/storefront-app-router/app/products/[id]/page.tsx
+++ b/examples/nextjs/storefront-app-router/app/products/[id]/page.tsx
@@ -1,15 +1,12 @@
-import { FirmhouseClient } from '@firmhouse/firmhouse-sdk';
 import { Product } from '@firmhouse/ui-components';
+import { firmhouseClient } from '../../../lib/firmhouse';
 
 export default async function ProductPage({
   params,
 }: {
   params: { id: string };
 }) {
-  const client = new FirmhouseClient({
-    apiToken: process.env.PROJECT_ACCESS_TOKEN ?? '',
-  });
-  const product = await client.products.fetchById(params.id);
+  const product = await firmhouseClient.products.fetchById(params.id);
   return (
     <div className="flex h-full w-full justify-center align-middle flex-col">
       {product !== null && (


### PR DESCRIPTION
Redirection after fetching the payment URL was broken. Next.js is using special errors to handle redirection. As we were calling redirect in try catch block, the error was being watched by the catch block. Therefore it was not redirecting the user to payment page.

This PR fixes the issue by calling redirect outside the try/catch block.