### PR TITLE
Fix subscription creation issue

### DIFF
--- a/examples/nextjs/storefront-app-router/app/checkout/page.tsx
+++ b/examples/nextjs/storefront-app-router/app/checkout/page.tsx
@@ -24,7 +24,7 @@ export default async function Index() {
       <div className="flex flex-row w-11/12 max-w-5xl bg-white shadow-sm border rounded-md border-gray-100 flex-nowrap m-16">
         <CheckoutForm subscription={subscription} />
         <div className="flex-auto p-6 shadow-[-3px_0_12px_0_rgb(0,0,0,0.1)] ">
-          <div className="">
+          <div>
             <h2 className="font-bold text-xl px-2">Cart</h2>
             {orderedProducts?.map((orderedProduct) => (
               <CartProduct

--- a/examples/nextjs/storefront-app-router/app/page.tsx
+++ b/examples/nextjs/storefront-app-router/app/page.tsx
@@ -1,8 +1,8 @@
+import { redirect } from 'next/navigation';
 import {
   getSubscriptionToken,
   addToCart,
   removeFromCart,
-  isInitialized,
   updateQuantity,
 } from '../lib/actions/subscription';
 import { firmhouseClient } from '../lib/firmhouse';
@@ -10,26 +10,31 @@ import Cart from '../components/Cart';
 import ProductList from '../components/ProductList';
 
 export default async function Index() {
-  const products = await firmhouseClient.products.fetchAll();
-  let subscription = null;
-  if (await isInitialized()) {
+  let subscription;
+  try {
     subscription = await firmhouseClient.subscriptions.get(
       await getSubscriptionToken()
     );
+  } catch (e) {
+    // If the subscription does not exist or not in draft state it will throw an error
+    // We can safely ignore this error and redirect the user to subscription creation route handler
+    return redirect('/subscription/create');
   }
-
+  // We fetch products after we get a subscription to prevent unnecessary API calls
+  const products = await firmhouseClient.products.fetchAll();
+  
   return (
-      <div className="flex h-full w-full justify-start flex-row mt-12 pr-[300px]">
-        <div className="p-8 w-full">
-          <ProductList products={products} addToCart={addToCart} />
-        </div>
-        <div className="h-full bg-white w-[300px] fixed top-0 right-0 pt-8">
-          <Cart
-            subscription={subscription}
-            onRemove={removeFromCart}
-            onUpdateQuantity={updateQuantity}
-          />
-        </div>
+    <div className="flex h-full w-full justify-start flex-row mt-12 pr-[300px]">
+      <div className="p-8 w-full">
+        <ProductList products={products} addToCart={addToCart} />
       </div>
+      <div className="h-full bg-white w-[300px] fixed top-0 right-0 pt-8">
+        <Cart
+          subscription={subscription}
+          onRemove={removeFromCart}
+          onUpdateQuantity={updateQuantity}
+        />
+      </div>
+    </div>
   );
 }

--- a/examples/nextjs/storefront-app-router/app/subscription/create/route.ts
+++ b/examples/nextjs/storefront-app-router/app/subscription/create/route.ts
@@ -1,0 +1,8 @@
+import { redirect } from "next/navigation";
+import { initializeCart } from "../../../lib/actions/subscription";
+
+export async function GET(request: Request) {
+    // Initialize subscription cart
+    await initializeCart();
+    redirect('/')
+}

--- a/examples/nextjs/storefront-app-router/lib/actions/subscription.ts
+++ b/examples/nextjs/storefront-app-router/lib/actions/subscription.ts
@@ -17,6 +17,10 @@ export async function getSubscriptionToken(): Promise<string> {
   return cookies().get(SUBSCRIPTION_TOKEN_COOKIE)?.value ?? '';
 }
 
+export async function clearSubscriptionToken(): Promise<void> {
+  cookies().delete(SUBSCRIPTION_TOKEN_COOKIE);
+}
+
 export async function initializeCart() {
   const subscriptionToken =
     cookies().get(SUBSCRIPTION_TOKEN_COOKIE)?.value ?? undefined;


### PR DESCRIPTION
After user completes payment for a subscription as it's status changes to `ACTIVATED`, we can't access that with a storefront  token. The app was not checking this and when it can find the subscription token in cookies, it was trying to fetch the subscription with that token and it was failing.
This PR solves that by creating a route handler `/subscription/create` to initialize the subscription whenever user opens the main page. It first tries to fetch the subscription with given token and if it fails, it redirects to `/subscription/create` to initialize it first and then route handler redirects the user back to main page with valid subscription token in cookies.