### PR TITLE
Update publish registry from GitHub to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          registry-url: https://npm.pkg.github.com/
+          registry-url: 'https://registry.npmjs.org'
           scope: '@firmhouse'
           node-version: 18
           cache: 'npm'
@@ -41,5 +41,4 @@ jobs:
         run: npx nx affected --target release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR updates the GitHub action parameters to replace the package publishing registry from GitHub packages to NPM.