### PR TITLE
Fix release config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,6 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@firmhouse'
           node-version: 18
           cache: 'npm'
       - run: npm ci


### PR DESCRIPTION
The registry URL variable for the setup-node step was creating an npmrc file without an authentication token. So later when we were using the release step it was causing the access to fail.